### PR TITLE
Make voltageReference a configurable parameter

### DIFF
--- a/GP2YDustSensor.cpp
+++ b/GP2YDustSensor.cpp
@@ -13,10 +13,12 @@
 GP2YDustSensor::GP2YDustSensor(GP2YDustSensorType type,
                                uint8_t ledOutputPin,
                                uint8_t analogReadPin,
-                               uint16_t runningAverageCount)
+                               uint16_t runningAverageCount,
+                               float voltageReference)
 {
     this->ledOutputPin = ledOutputPin;
     this->analogReadPin = analogReadPin;
+    this->vRef = voltageReference;
     this->type = type;
     this->sensitivity = 0.5; // default sensitivity from datasheet
     this->nextRunningAverageCounter = 0;
@@ -153,7 +155,7 @@ uint16_t GP2YDustSensor::readDustRawOnce()
  * 
  * @return uint16_t dust density between 0 and 600 ug/m3
  */
-uint16_t GP2YDustSensor::getDustDensity(uint16_t numSamples, float vRef)
+uint16_t GP2YDustSensor::getDustDensity(uint16_t numSamples)
 {
     uint32_t total = 0;
     uint16_t avgRaw;
@@ -169,7 +171,7 @@ uint16_t GP2YDustSensor::getDustDensity(uint16_t numSamples, float vRef)
     // we scale up the read ADC voltage to the vRef input range
     // so we can interpret the results based on voltage
     // we assume a 10 bit ADC resolution currently given by analogRead()
-    float scaledVoltage = avgRaw * (vRef / 1024) * calibrationFactor;
+    float scaledVoltage = avgRaw * (this->vRef / 1024) * calibrationFactor;
 
     // determine new baseline candidate
     if (scaledVoltage < this->minDustVoltage && scaledVoltage >= minZeroDustVoltage && scaledVoltage <= maxZeroDustVoltage) {

--- a/GP2YDustSensor.cpp
+++ b/GP2YDustSensor.cpp
@@ -153,7 +153,7 @@ uint16_t GP2YDustSensor::readDustRawOnce()
  * 
  * @return uint16_t dust density between 0 and 600 ug/m3
  */
-uint16_t GP2YDustSensor::getDustDensity(uint16_t numSamples)
+uint16_t GP2YDustSensor::getDustDensity(uint16_t numSamples, float vRef)
 {
     uint32_t total = 0;
     uint16_t avgRaw;
@@ -166,10 +166,10 @@ uint16_t GP2YDustSensor::getDustDensity(uint16_t numSamples)
 
     avgRaw = total / numSamples;
 
-    // we scale up the read ADC voltage to the sensor's 5V output range
+    // we scale up the read ADC voltage to the vRef input range
     // so we can interpret the results based on voltage
     // we assume a 10 bit ADC resolution currently given by analogRead()
-    float scaledVoltage = avgRaw * (5.0 / 1024) * calibrationFactor;
+    float scaledVoltage = avgRaw * (vRef / 1024) * calibrationFactor;
 
     // determine new baseline candidate
     if (scaledVoltage < this->minDustVoltage && scaledVoltage >= minZeroDustVoltage && scaledVoltage <= maxZeroDustVoltage) {

--- a/GP2YDustSensor.cpp
+++ b/GP2YDustSensor.cpp
@@ -8,6 +8,7 @@
  * @param uint8_t analogReadPin - the analog input pin connected from the Sharp analog output (Vo).
  * On ESP8266 there is a single A0 pin
  * @param uint16_t runningAverageCount - number of samples taken for the running average.
+ * @param float voltageReference - analog voltage reference for analogRead(analogReadPin)
  * use 0 to disable running average
  */
 GP2YDustSensor::GP2YDustSensor(GP2YDustSensorType type,

--- a/GP2YDustSensor.h
+++ b/GP2YDustSensor.h
@@ -37,7 +37,7 @@ class GP2YDustSensor
         GP2YDustSensor(GP2YDustSensorType type, uint8_t ledOutputPin, uint8_t analogReadPin, uint16_t runningAverageCount = 60);
         ~GP2YDustSensor();
         void begin();
-        uint16_t getDustDensity(uint16_t numSamples = 20);
+        uint16_t getDustDensity(uint16_t numSamples = 20, float vRef = 5.0);
         uint16_t getRunningAverage();
         float getBaseline();
         void setBaseline(float zeroDustVoltage);

--- a/GP2YDustSensor.h
+++ b/GP2YDustSensor.h
@@ -13,6 +13,7 @@ class GP2YDustSensor
         uint32_t maxAdc;
         uint8_t ledOutputPin;
         uint8_t analogReadPin;
+        float vRef;
         float zeroDustVoltage;
         float minDustVoltage;
         float minZeroDustVoltage;
@@ -34,10 +35,14 @@ class GP2YDustSensor
         void updateRunningAverage(uint16_t dustDensity);
 
     public:
-        GP2YDustSensor(GP2YDustSensorType type, uint8_t ledOutputPin, uint8_t analogReadPin, uint16_t runningAverageCount = 60);
+        GP2YDustSensor(GP2YDustSensorType type,
+                uint8_t ledOutputPin,
+                uint8_t analogReadPin,
+                uint16_t runningAverageCount = 60,
+                float voltageReference = 5.0);
         ~GP2YDustSensor();
         void begin();
-        uint16_t getDustDensity(uint16_t numSamples = 20, float vRef = 5.0);
+        uint16_t getDustDensity(uint16_t numSamples = 20);
         uint16_t getRunningAverage();
         float getBaseline();
         void setBaseline(float zeroDustVoltage);

--- a/README.md
+++ b/README.md
@@ -24,16 +24,18 @@ Create an object of type `GP2YDustSensor` specifying the type, the GPIO pin driv
  * On ESP8266 there is a single A0 pin
  * @param uint16_t runningAverageCount - number of samples taken for the running average.
  * use 0 to disable running average
+ * @param float voltageReference - analog voltage reference for analogRead(analogReadPin)
  */
 GP2YDustSensor::GP2YDustSensor(GP2YDustSensorType type,
                                uint8_t ledOutputPin,
                                uint8_t analogReadPin,
-                               uint16_t runningAverageCount)
+                               uint16_t runningAverageCount,
+                               float voltageReference)
 ```
 
 The forth parameter can be used to specify how many samples are used for calculating the running average.
 
-Call `dustSensor.init()` somewhere in the `setup()` method to initialize the sensor.
+Call `dustSensor.begin()` somewhere in the `setup()` method to initialize the sensor.
 Then use `dustSensor.getDustDensity()` to obtain an average dust average for the number of samples specified (default 20):
 
 ```c++


### PR DESCRIPTION
It's helpful to be able to use an alternate voltage reference on various boards.  

Default to 5.0V for common Uno / Nano setup, but allow changing reference for better accuracy on non-5.0V reference boards (e.g. 3.2V reference on some esp8266 boards).